### PR TITLE
Address travis build issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ script:
   - npm test
   - npm run build:app
   - npm run pack
+  - rm -rf node_modules 
   - cd app/
   - npm install brewcalc.tgz
   - npm test

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2809,7 +2809,7 @@
     },
     "brewcalc": {
       "version": "file:brewcalc.tgz",
-      "integrity": "sha512-AQ70DOrvD/3dWpqL73yNL8RisKEtlLZ+JlbAQTTZHrEhHrGKpgVL2AeihWtDaoaXlhIqMNUj+sqU4EvfGM2L+Q=="
+      "integrity": "sha512-/5to8Mywao5Cx+MpLhfgWmFJJqQrHS53HNrLPuyeMgLSG/AniWocquRZhBoxvv8/PCC2+O6mp6vrKgcMFC6MUQ=="
     },
     "brorand": {
       "version": "1.1.0",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2809,7 +2809,7 @@
     },
     "brewcalc": {
       "version": "file:brewcalc.tgz",
-      "integrity": "sha512-/5to8Mywao5Cx+MpLhfgWmFJJqQrHS53HNrLPuyeMgLSG/AniWocquRZhBoxvv8/PCC2+O6mp6vrKgcMFC6MUQ=="
+      "integrity": "sha512-AQ70DOrvD/3dWpqL73yNL8RisKEtlLZ+JlbAQTTZHrEhHrGKpgVL2AeihWtDaoaXlhIqMNUj+sqU4EvfGM2L+Q=="
     },
     "brorand": {
       "version": "1.1.0",


### PR DESCRIPTION
This PR is an attempt to address [the most recent failing travis builds](https://travis-ci.org/github/brewcomputer/brewcalc/builds/724037096).
```
$ npm test
> brewcalc-ui@0.1.0 test /home/travis/build/brewcomputer/brewcalc/app
> react-scripts test --env=jsdom
There might be a problem with the project dependency tree.
It is likely not a bug in Create React App, but something you need to fix locally.
The react-scripts package provided by Create React App requires a dependency:
  "babel-jest": "23.6.0"
Don't try to install it manually: your package manager does it automatically.
However, a different version of babel-jest was detected higher up in the tree:
  /home/travis/build/brewcomputer/brewcalc/node_modules/babel-jest (version: 24.8.0)
```

The build issue appears to be the result of npm using the parent directory's node_modules when attempting to resolve dependencies for the `app/` travis steps.  Removing the node_modules folder from the project root after the main library has been built should prevent the errors seen in travis.

PS: Apologies for the random PR.  I'm planning on using this library in a personal recipe building tool.  I may be interested in adding a few new features to the library in the future and figured I'd start by addressing the small build issue.